### PR TITLE
Tweak directory structure in macOS build script

### DIFF
--- a/build/macos/build-macos
+++ b/build/macos/build-macos
@@ -61,7 +61,7 @@ arduino_compile() {
 
    keymapHeaderFile="$keyboardsPath/$keyboard/keymaps/$keymap/keymap.h"
    keymapSourceFile="$keyboardsPath/$keyboard/keymaps/$keymap/keymap.cpp"
-   configFile="$keyboardsPath/$keyboard/$target/keyboard_config.h"
+   configFile="$keyboardsPath/$keyboard/config/$target/keyboard_config.h"
 
    cp -f $keymapHeaderFile $sourcePath/
    cp -f $keymapSourceFile $sourcePath/
@@ -231,7 +231,7 @@ do
    done
 
    targets=()
-   for target in $sourcePath/keyboards/$keyboard/*/
+   for target in $sourcePath/keyboards/$keyboard/config/*/
    do
       target=${target%*/}
       target=${target##*/}


### PR DESCRIPTION
There were some changes in [this commit](https://github.com/jpconstantineau/BlueMicro_BLE/commit/bf28ffa12f83c3f06c3869fe46f9e4b235b72136) that updated the Ubuntu script to reflect some changes to the firmware directory structure. This adds that same tweak to the macOS build script.

NOTE there were some other tweaks in that commit that added some additional flexibility to the Ubuntu script; namely hardware targeting. Full disclosure, I haven't added that here, just trying to get this running given those hardware defaults.